### PR TITLE
use Feral snapshot to test the CloudFormation Custom Resource response fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,10 @@ lazy val `postgresql-init-core` = (project in file("."))
   .settings(
     maintainer := developers.value.head.email,
     topLevelDirectory := None,
+    resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= {
       val natchezVersion = "0.1.6"
-      val feralVersion = "0.1.0-M1"
+      val feralVersion = "0.1-288f0f5-SNAPSHOT"
 
       Seq(
         "org.typelevel" %% "feral-lambda-cloudformation-custom-resource" % feralVersion,


### PR DESCRIPTION
Feral's implementation mistakenly used POST instead of PUT for writing the CloudFormation Custom Resource response to S3, causing it to fail. The fix has been merged, but there are issues publishing the new milestone release, so this lets us use the snapshot artifact until those issues are resolved.