### PR TITLE
use Feral snapshot to test fixes to response publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val `postgresql-init-core` = (project in file("."))
     resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= {
       val natchezVersion = "0.1.6"
-      val feralVersion = "0.1-288f0f5-SNAPSHOT"
+      val feralVersion = "0.1-b2e99d0-SNAPSHOT"
 
       Seq(
         "org.typelevel" %% "feral-lambda-cloudformation-custom-resource" % feralVersion,


### PR DESCRIPTION
CloudFormation expects a fairly specific JSON object be uploaded to S3 as a response when a custom resource completes its work. The previous milestone of Feral was not serializing it in quite the correct format, but this snapshot should fix that problem. Once we report success, Feral will publish a new milestone (which we'll want to adopt ASAP).